### PR TITLE
add "branch" parameter to select status for latest build of specific branch

### DIFF
--- a/BuildbotStatusShields/__init__.py
+++ b/BuildbotStatusShields/__init__.py
@@ -8,12 +8,12 @@ def bind(webstatus, path="badge", left_text=None, left_color=None,
          template=None, font_face=None, font_size=None, color_scheme=None):
     """Installs the ShieldStatusResource in the given WebStatus instance
     """
-    left_text = left_text or ShieldStatusResource.defaults['leftText']
-    left_color = left_color or ShieldStatusResource.defaults['leftColor']
-    template_name = template or ShieldStatusResource.defaults['templateName']
-    font_face = font_face or ShieldStatusResource.defaults['fontFace']
-    font_size = font_size or ShieldStatusResource.defaults['fontSize']
-    color_scheme = color_scheme or ShieldStatusResource.defaults['colorScheme']
+    left_text = left_text or ShieldStatusResource.defaults['left_text']
+    left_color = left_color or ShieldStatusResource.defaults['left_color']
+    template_name = template or ShieldStatusResource.defaults['template_name']
+    font_face = font_face or ShieldStatusResource.defaults['font_face']
+    font_size = font_size or ShieldStatusResource.defaults['font_size']
+    color_scheme = color_scheme or ShieldStatusResource.defaults['color_scheme']
 
     for filetype in ["png", "svg"]:
         webstatus.putChild("%s.%s" % (path, filetype),

--- a/BuildbotStatusShields/shields.py
+++ b/BuildbotStatusShields/shields.py
@@ -110,6 +110,9 @@ class ShieldStatusResource(resource.Resource):
         # build number
         build_number = int(request.args.get('number', [-1])[0])
 
+		# branch
+        branch = request.args.get('branch', [None])[0]
+
         filetype = request.path.split(".")[-1].lower()
         mimetypes = {
             "svg": "image/svg+xml",
@@ -122,18 +125,30 @@ class ShieldStatusResource(resource.Resource):
                 'image': None,
                 'content_type': mimetypes[filetype]}
 
-        builder = request.args.get('builder', [None])[0]
+        builder_name= request.args.get('builder', [None])[0]
 
         svgdata = self.makesvg("Unknown", left_text="Image Error")
-        if builder is not None and builder in status.getBuilderNames():
-            # get the last build result from this builder
-            build = status.getBuilder(builder).getBuild(build_number)
-            if build is not None:
-                result = build.getResults()
-                svgdata = self.makesvg(results.Results[result],
-                                       results.Results[result])
-            else:
-                svgdata = self.makesvg("No builds", left_text="Image Error")
+        if builder_name is not None and builder_name in status.getBuilderNames():
+			builder = status.getBuilder(builder_name)
+			#get the last build from this branch:
+			if branch:
+				number = builder.nextBuildNumber - 1
+				while number > 0:
+					build = builder.getBuildByNumber(number)
+					if branch in [ss.branch for ss in build.getSourceStamps()]:
+						break
+					number -= 1
+				if number > 0:
+					build_number = number
+		 	if not branch or build_number > 0:
+				# get the last build result from this builder
+				build = builder.getBuild(build_number)
+				if build is not None:
+					result = build.getResults()
+					svgdata = self.makesvg(results.Results[result],
+							   results.Results[result], left_text=self.left_text + ": " + branch)
+				else:
+					svgdata = self.makesvg("No builds", left_text="Image Error")
         else:
             svgdata = self.makesvg("Invalid builder", left_text="Image Error")
 

--- a/BuildbotStatusShields/shields.py
+++ b/BuildbotStatusShields/shields.py
@@ -38,7 +38,7 @@ class ShieldStatusResource(resource.Resource):
     defaults = {
         "left_text": "Build Status",
         "left_color": "#555",
-        "template_name": "badge.svg.s2",
+        "template_name": "badge.svg.j2",
         "font_face": "DejaVu Sans",
         "font_size": 11,
         "color_scheme": {
@@ -56,7 +56,7 @@ class ShieldStatusResource(resource.Resource):
     templateName = None
     fontFace = None
     fontSize = None
-    colorScheme = defaults['colorScheme']
+    colorScheme = defaults['color_scheme']
 
     env = jinja2.Environment(loader=jinja2.ChoiceLoader([
         jinja2.PackageLoader('BuildbotStatusShields'),


### PR DESCRIPTION
Hi,

I fixed some template name and default key errors and added an additional, optional parameter "branch" to show the status badge for the latest build for a specific branch. It is useful to distinguish the status values of builds triggered by an AnyBranchScheduler.

Best, Martin
